### PR TITLE
Add the use of EC2_METADATA_DUMMY_YAML env variable to README

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -30,14 +30,18 @@ For more detail, type
 
 
 == Dummy YAML
-If you want to access meta-data or user-data not on EC2 Instance like on it,
-make one of these files
+Use a Dummy YAML file to mimic meta-data or user-data similiar to an EC2 Instance
+
+You can make one of these files:
  ./config/ec2_metadata.yml
  ./ec2_metadata.yml
  ~/ec2_metadata.yml
  /etc/ec2_metadata.yml
 
-Dummy YAML file must be like output of ec2-metadata on EC2 instance.
+You can also specify the path to a file by defining the `EC2_METADATA_DUMMY_YAML` environment variable
+ $ export EC2_METADATA_DUMMY_YAML=/path/to/dummy/yaml/file.yml
+
+The content of the Dummy YAML file must be like the output of ec2-metadata on an EC2 instance.
 You can export it on EC2 instance like this:
  $ ec2-medatata > ec2_metadata.yml
  $ cp ec2_metadata.yml /path/to/dir/for/non/ec2/instance


### PR DESCRIPTION
Only after looking into the code, I found using the EC2_METADATA_DUMMY_YAML file very useful. I used it to help get some specs passing locally in a non-EC2 instance.

I feel like adding this in the README would greatly help others who would like to customize the location of the dummy yaml file.
